### PR TITLE
feat: Add LLMLogs command to display llm logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ require('pelican').setup({
 - `:Scratch` - Create a new Markdown scratch file with a timestamp based name.
 - `:OpenLatestScratch` - Open last modified file in scratch folder.
 - `:LLM` - Call LLM with the current buffer or visual selection as input. Streams output to a new scratch buffer in a vertical split window. Can also take command line args as expected. e.g. `:LLM -m claude-3.7-sonnet`
+- `:LLMLogs` - Outputs the result of `llm logs` to a new scratch buffer. Also takes command line args as expected e.g. `:LLMLogs -r`
 - `:YankCodeBlock` - Yank buffer/selection as Markdown code block.
 - `:SelectCodeBlock` - If the cursor is within a Markdown code block, visually select the content of the code block.
 

--- a/plugin/pelican.vim
+++ b/plugin/pelican.vim
@@ -6,10 +6,9 @@ let g:loaded_pelican = 1
 lua require('pelican')
 
 command! -nargs=* -range=% -bar LLM lua require('pelican').handle_command(<line1>, <line2>, vim.fn.mode(), <q-args>)
-
+command! -nargs=* LLMLogs lua require('pelican').handle_logs_command(<q-args>)
 command! -nargs=0 Scratch lua require('pelican.scratch').create_scratch_file()
 command! -nargs=0 OpenLatestScratch lua require('pelican.scratch').open_latest_scratch()
 command! -nargs=0 SelectCodeBlock lua require('pelican.scratch').select_within_code_block()
 lua vim.api.nvim_create_user_command('YankCodeBlock', require('pelican.scratch').yank_as_codeblock, {range = '%'})
-
 lua require('pelican.scratch').setup_scratch_autosave()


### PR DESCRIPTION
This commit introduces a new command, `:LLMLogs`, which displays the output of `llm logs` in a new scratch buffer. It also allows passing command-line arguments to `llm logs`.