### PR TITLE
Modify how `:LLM` command creates splits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ require('pelican').setup({
 
 - `:Scratch` - Create a new Markdown scratch file with a timestamp based name.
 - `:OpenLatestScratch` - Open last modified file in scratch folder.
-- `:LLM` - Call LLM with the current buffer or visual selection as input. Streams output to a new scratch buffer in a vertical split window. Can also take command line args as expected. e.g. `:LLM -m claude-3.7-sonnet`
+- `:LLM` - Call LLM with the current buffer or visual selection as input. Streams output to a new scratch buffer (first in a vertical split window, then subsequent calls will horizontal split off the first). Can also take command line args as expected. e.g. `:LLM -m claude-3.7-sonnet`
 - `:LLMLogs` - Outputs the result of `llm logs` to a new scratch buffer. Also takes command line args as expected e.g. `:LLMLogs -r`
-- `:YankCodeBlock` - Yank buffer/selection as Markdown code block.
+- `:YankCodeBlock` - Yank buffer/selection as Markdown code block (wrapped in backticks and labelled with language/filetype).
 - `:SelectCodeBlock` - If the cursor is within a Markdown code block, visually select the content of the code block.
 
 #### Note


### PR DESCRIPTION
Description of new behavior from modified README.md:
first in a vertical split window, then subsequent calls will horizontal split off the first